### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,29 @@
+import sqlite3
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from converter import LandUnitsConverter
+
+
+def _setup_db(db_path):
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+    cur.execute("CREATE TABLE units (unit_id TEXT PRIMARY KEY, m2_value REAL)")
+    cur.executemany(
+        "INSERT INTO units (unit_id, m2_value) VALUES (?, ?)",
+        [("u1", 1.0), ("u2", 10.0)],
+    )
+    con.commit()
+    con.close()
+
+
+def test_convert_basic(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    _setup_db(db_file)
+    conv = LandUnitsConverter(str(db_file))
+    result = conv.convert(2, "u1", "u2")
+    assert result["conversion_factor"] == pytest.approx(0.1)
+    assert result["result"] == pytest.approx(0.2)

--- a/tests/test_verify_database.py
+++ b/tests/test_verify_database.py
@@ -1,0 +1,41 @@
+import sqlite3
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from verify_data import verify_database
+
+
+def _create_tables(cur):
+    cur.execute("CREATE TABLE units (unit_id TEXT PRIMARY KEY, m2_value REAL)")
+    cur.execute("CREATE TABLE unit_equivalents (id INTEGER)")
+    cur.execute("CREATE TABLE unit_references (id INTEGER)")
+    cur.execute("CREATE TABLE unit_variations (id INTEGER)")
+
+
+def test_verify_database_valid(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    con = sqlite3.connect(db_file)
+    cur = con.cursor()
+    _create_tables(cur)
+    for i in range(5):
+        cur.execute("INSERT INTO units VALUES (?, ?)", (f"u{i}", float(i+1)))
+    for i in range(3):
+        cur.execute("INSERT INTO unit_equivalents VALUES (?)", (i,))
+    con.commit()
+    con.close()
+    verify_database(str(db_file))
+
+
+def test_verify_database_invalid_counts(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    con = sqlite3.connect(db_file)
+    cur = con.cursor()
+    _create_tables(cur)
+    cur.execute("INSERT INTO units VALUES ('u1', 1.0)")
+    con.commit()
+    con.close()
+    with pytest.raises(AssertionError):
+        verify_database(str(db_file))


### PR DESCRIPTION
## Summary
- add pytest unit tests for LandUnitsConverter conversion
- add tests covering verify_database validation
- run pytest in GitHub Actions on pushes and pull requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24b2db1288331922bc7ad05f3468f