### PR TITLE
Add Flutter demo for land unit converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ python src/verify_data.py
 ```
 python web/app.py
 ```
+
+## Flutter Demo
+يوجد مثال مبسط للمشروع باستخدام Flutter داخل مجلد `flutter_app`.
+لتشغيله بعد تثبيت Flutter:
+```
+cd flutter_app
+flutter run
+```

--- a/flutter_app/lib/land_units_converter.dart
+++ b/flutter_app/lib/land_units_converter.dart
@@ -1,0 +1,85 @@
+import 'dart:collection';
+
+/// Represents a single land measurement unit.
+class Unit {
+  final String id;
+  final double m2Value;
+  final String? displayName;
+  final String? country;
+  final String? region;
+
+  const Unit({
+    required this.id,
+    required this.m2Value,
+    this.displayName,
+    this.country,
+    this.region,
+  });
+}
+
+/// Result of a conversion between two units.
+class ConversionResult {
+  final double inputValue;
+  final String fromUnit;
+  final String toUnit;
+  final String? region;
+  final double conversionFactor;
+  final double result;
+  final DateTime timestamp;
+
+  ConversionResult({
+    required this.inputValue,
+    required this.fromUnit,
+    required this.toUnit,
+    this.region,
+    required this.conversionFactor,
+    required this.result,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  Map<String, dynamic> toMap() => {
+        'input_value': inputValue,
+        'from_unit': fromUnit,
+        'to_unit': toUnit,
+        'region': region,
+        'conversion_factor': conversionFactor,
+        'result': result,
+        'timestamp': timestamp.toIso8601String(),
+      };
+}
+
+/// In-memory implementation of the land units converter.
+class LandUnitsConverter {
+  final Map<String, Unit> _units;
+
+  LandUnitsConverter(Map<String, Unit> units) : _units = HashMap.of(units);
+
+  double _fetchM2(String unitId, [String? region]) {
+    final unit = _units[unitId];
+    if (unit == null) {
+      throw ArgumentError('الوحدة غير موجودة: $unitId');
+    }
+    return unit.m2Value;
+  }
+
+  ConversionResult convert(double value, String fromUnit, String toUnit,
+      {String? region}) {
+    final fromM2 = _fetchM2(fromUnit, region);
+    final toM2 = _fetchM2(toUnit, region);
+    final factor = fromM2 / toM2;
+    return ConversionResult(
+      inputValue: value,
+      fromUnit: fromUnit,
+      toUnit: toUnit,
+      region: region,
+      conversionFactor: factor,
+      result: value * factor,
+    );
+  }
+
+  List<Unit> listUnits({String? country}) {
+    return _units.values
+        .where((u) => country == null || u.country == country)
+        .toList();
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'land_units_converter.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final converter = LandUnitsConverter({
+      'u1': const Unit(id: 'u1', m2Value: 1.0, displayName: 'Unit 1'),
+      'u2': const Unit(id: 'u2', m2Value: 10.0, displayName: 'Unit 2'),
+    });
+    final result = converter.convert(2, 'u1', 'u2');
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Land Units Converter')),
+        body: Center(
+          child: Text('2 u1 = ${result.result} u2'),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,12 @@
+name: land_units_converter
+version: 0.1.0
+publish_to: none
+description: A Flutter demo for land units conversion.
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- provide a Flutter/Dart implementation of the land unit converter
- include a simple Flutter app demonstrating unit conversion
- document how to run the Flutter example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abadae5e048331bf6014b920c0e793